### PR TITLE
Add playlist empty title check

### DIFF
--- a/static/js/player/sidebarview.js
+++ b/static/js/player/sidebarview.js
@@ -11,7 +11,7 @@ SidebarView = Backbone.View.extend({
   },
   addPlaylist: function(){
     bootbox.prompt("Playlist title?", function(result){
-      if (result !== null) {
+      if (result !== null && result !== "") {
         socket.emit('create_playlist', {title: result, songs: []});
       }
     });


### PR DESCRIPTION
Adding an new playlist with an empty title will no longer add a blank playlist. Used to render as below: 
<img width="275" alt="screen shot 2015-08-27 at 9 28 55 pm" src="https://cloud.githubusercontent.com/assets/8270120/9539157/a6bead70-4d02-11e5-9920-77d11e39e75e.png">

Now attempting to add playlist with blank title won't create playlist. 