### PR TITLE
Fix md5 dependency issue, closes #56

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "nodemon app.js -e 'html css js'"
   },
   "dependencies": {
-    "MD5": "*",
+    "md5": "*",
     "adm-zip": "*",
     "async": "*",
     "express-http-proxy": "^0.3.0",


### PR DESCRIPTION
`npm WARN deprecated MD5@1.3.0: deprecated, use lowercase 'md5@2.x' from now on`

so I did.